### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,17 @@ To update your clone:
 
 ### Dependencies
 
+**All:**
+
 * [Razer Python Modules](https://github.com/pez2001/razer_chroma_drivers)
-* gir1.2-webkit-3.0
-* python3-gi
-* gir1.2-appindicator3-0.1
+
+**Arch:**
+* [webkitgtk](https://www.archlinux.org/packages/extra/x86_64/webkitgtk/)
+* [python-gobject](https://www.archlinux.org/packages/extra/x86_64/python-gobject/)
+* [libappindicator](https://aur.archlinux.org/pkgbase/libappindicator/?comments=all)
+
+**Debian:**
+* [gir1.2-webkit2-4.0](https://packages.debian.org/sid/gir1.2-webkit2-4.0)
+* [python3-gi](https://packages.debian.org/sid/python3-gi)
+* [gir1.2-appindicator3-0.1](https://packages.debian.org/sid/gir1.2-appindicator3-0.1)
 


### PR DESCRIPTION
If `gir1.2-webkit-3.0` is installed (per the readme), the program will crash with the following error:

```
Traceback (most recent call last):
  File "/usr/bin/polychromatic-controller", line 23, in <module>
    gi.require_version('WebKit2', '4.0')
  File "/usr/lib/python3/dist-packages/gi/__init__.py", line 106, in require_version
    (namespace, version))
ValueError: Namespace WebKit2 not available for version 4.0
```

I also separated the deps into different lists since the names are very different between distros, and added links (hoping that the page's descriptions might be useful to any other distro users).