### PR TITLE
Support WebKit2GTK < 2.14 again

### DIFF
--- a/polychromatic-controller
+++ b/polychromatic-controller
@@ -134,7 +134,10 @@ class AppView(WebKit2.WebView):
         try:
             # Allows Keyboard SVGs to load.
             self.get_settings().set_allow_file_access_from_file_urls(True)
-            self.get_settings().set_allow_universal_access_from_file_urls(True)
+            try:
+                self.get_settings().set_allow_universal_access_from_file_urls(True)
+            except AttributeError:
+                print("Ignoring set_allow_universal_access_from_file_urls because the WebKit2GTK version is <2.14.")
 
             # Print console log errors to stdout
             self.get_settings().set_enable_write_console_messages_to_stdout(True)


### PR DESCRIPTION
allow_universal_access_from_file_urls is only supported since v2.14 and
previous versions don't seem to need that/a similar call.

Introduced in: 5dbd6773333997847a55b99a8c864d570ed744fe